### PR TITLE
Use Camel-K version 1.0.0-M1 and Knative version 0.7.1

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: knative-tutorial-camelk
 title: Eventing with Apache Camel
-version: 1.0.0-M1
+version: 1.0.0-M3
 nav:
   - modules/ROOT/nav.adoc
 start_page: ROOT:index.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: knative-tutorial-camelk
 title: Eventing with Apache Camel
-version: 0.3.3
+version: 1.0.0-M1
 nav:
   - modules/ROOT/nav.adoc
 start_page: ROOT:index.adoc

--- a/modules/ROOT/pages/_attributes.adoc
+++ b/modules/ROOT/pages/_attributes.adoc
@@ -5,6 +5,6 @@
 :camelk-demos-github-repo-uri: https://github.com/redhat-developer-demos/knative-tutorial-camelk
 :camelk-demos-github-repo: {camelk-demos-github-repo-uri}/blob/{branch}
 :camelk-repo: advanced/camel-k
-:kamel-version: 0.3.3
+:kamel-version: 1.0.0-M1
 :experimental:
 :maven-version: 3.6.0+

--- a/modules/ROOT/pages/_attributes.adoc
+++ b/modules/ROOT/pages/_attributes.adoc
@@ -5,6 +5,6 @@
 :camelk-demos-github-repo-uri: https://github.com/redhat-developer-demos/knative-tutorial-camelk
 :camelk-demos-github-repo: {camelk-demos-github-repo-uri}/blob/{branch}
 :camelk-repo: advanced/camel-k
-:kamel-version: 1.0.0-M1
+:kamel-version: 1.0.0-M3
 :experimental:
 :maven-version: 3.6.0+

--- a/modules/ROOT/pages/_partials/extras.adoc
+++ b/modules/ROOT/pages/_partials/extras.adoc
@@ -7,7 +7,7 @@
 ----
 K8S_LOCAL_REGISTRY=`{k8s-cli} get svc -n kube-system registry -ojsonpath='{.spec.clusterIP}'` && \ 
 val="pass:[${K8S_LOCAL_REGISTRY}]" && \
-{k8s-cli} -n knative-serving get cm config-controller -oyaml \
+{k8s-cli} -n knative-serving get cm config-deployment -oyaml \
   | yq w - data.registriesSkippingTagResolving $val \
   | {k8s-cli} apply -f -
 ----

--- a/modules/ROOT/pages/_partials/invoke-service.adoc
+++ b/modules/ROOT/pages/_partials/invoke-service.adoc
@@ -13,7 +13,7 @@ kubectl::
 [#camelk-{doc-sec}-svc-by-k8s]
 [source,bash,subs="+macros,+attributes"]
 ----
-SVC_URL=`kubectl -n {tutorial-namespace} get ksvc {svc-name} -ojsonpath='{.status.domain}'`
+SVC_URL=`kubectl -n {tutorial-namespace} get ksvc {svc-name} -ojsonpath='{..status.url}' | sed 's/^http:\/\///'`
 ----
 copyToClipboard::camelk-{doc-sec}-svc-by-k8s[]
 --
@@ -23,7 +23,7 @@ oc::
 [#camelk-{doc-sec}-svc-by-oc]
 [source,bash,subs="+macros,+attributes"]
 ----
-SVC_URL=`oc  -n {tutorial-namespace} get ksvc {svc-name} -ojsonpath='{.status.domain}'`
+SVC_URL=`oc  -n {tutorial-namespace} get ksvc {svc-name} -ojsonpath='{..status.url}' | sed 's/^http:\/\///'`
 ----
 copyToClipboard::camelk-{doc-sec}-svc-by-oc[]
 --

--- a/modules/ROOT/pages/_partials/minio-and-s3.adoc
+++ b/modules/ROOT/pages/_partials/minio-and-s3.adoc
@@ -10,7 +10,7 @@
 aws configure
 # AWS Access Key ID [None]: demoaccesskey #<1>
 # AWS Secret Access Key [None]: demosecretkey #<2>
-# Default region name [None]: 
+# Default region name [None]: local
 # Default output format [None]: 
 
 aws configure set default.s3.signature_version s3v4 #<3>

--- a/modules/ROOT/pages/content-based-router.adoc
+++ b/modules/ROOT/pages/content-based-router.adoc
@@ -169,6 +169,8 @@ kamel run \
   --property 's3EndpointUrl=http://minio-server' \
   --property 'minioAccessKey=demoaccesskey' \
   --property 'minioSecretKey=demosecretkey' \
+  --dependency camel-bean \
+  --dependency camel-xpath \
  link:{camelk-demos-github-repo}/quickstart/src/main/java/ComedyGenreHandler.java[src/main/java/ComedyGenreHandler.java]
 ----
 copyToClipboard::camelk-kamel-deploy-int[]
@@ -215,6 +217,8 @@ kamel run \
   --property 's3EndpointUrl=http://minio-server' \
   --property 'minioAccessKey=demoaccesskey' \
   --property 'minioSecretKey=demosecretkey' \
+  --dependency camel-bean \
+  --dependency camel-xpath \
  link:{camelk-demos-github-repo}/quickstart/src/main/java/OthersGenreHandler.java[src/main/java/OthersGenreHandler.java]
 ----
 copyToClipboard::camelk-deploy-others-genre-it[]
@@ -262,6 +266,8 @@ kamel run \
   --property 's3EndpointUrl=http://minio-server' \
   --property 'minioAccessKey=demoaccesskey' \
   --property 'minioSecretKey=demosecretkey' \
+  --dependency camel-bean \
+  --dependency camel-xpath \
  link:{camelk-demos-github-repo}/quickstart/src/main/java/CartoonGenreRouter.java[src/main/java/CartoonGenreRouter.java]
 ----
 copyToClipboard::camelk-deploy-cartoon-genre-it[]

--- a/modules/ROOT/pages/setup.adoc
+++ b/modules/ROOT/pages/setup.adoc
@@ -150,7 +150,7 @@ kamel install -n {tutorial-namespace}
 ----
 
 :kube-ns: knativetutorial
-includepartial$wait-for-pods.adoc[tag=wait-with-kubectl]
+include::partial$wait-for-pods.adoc[tag=wait-with-kubectl]
 
 [NOTE]
 ====
@@ -163,13 +163,7 @@ A successful camel-k setup will have the following pods running/completed in `{t
 ----
 # kubectl -n {tutorial-namespace} get pods | grep camel
 camel-k-cache                                              0/1     Completed   0          10h
-camel-k-ctx-bhq1ddi92mi5b779io60                           0/1     Completed   0          10h
-camel-k-groovy                                             0/1     Completed   0          10h
-camel-k-jvm                                                0/1     Completed   0          10h
-camel-k-knative                                            0/1     Completed   0          10h
-camel-k-kotlin                                             0/1     Completed   0          10h
 camel-k-operator-789b988bd9-9gzjn                          1/1     Running     0          10h
-camel-k-spring-boot                                        0/1     Completed   0          10h
 ----
 
 [TIP]


### PR DESCRIPTION
Hi @kameshsampath .. as discussed I made some updates to the tutorial to use it with Camel-K version 1.0.0-M1 and Knative version 0.7.1. I don't have the tools installed to generate the actual website, but the updates were only minor, so I suppose they will be fine. I am curious about the result.
In my environment (minikube 1.4.0 with k8s 1.15.3 on Ubuntu 18.04) I had to make some additional changes to the `kamel run` commands in order to fix some issue (as described in my pull request on the [sources](https://github.com/redhat-developer-demos/knative-tutorial/pull/179)). I am not sure however whether this issue is specific to my environment, so I decided to not add these changes to the documentation. Please let me know whether or not it's necessary to add these.